### PR TITLE
Shortcut range checks when all values in a leaf are the same

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/document/RangeFieldQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/document/RangeFieldQuery.java
@@ -136,6 +136,11 @@ abstract class RangeFieldQuery extends Query {
               }
               @Override
               public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                if (Arrays.equals(minPackedValue, maxPackedValue)) {
+                  if (queryType == QueryType.CONTAINS && comparator.isWithin(minPackedValue)) {
+                    return Relation.CELL_INSIDE_QUERY;
+                  }
+                }
                 byte[] node = getInternalRange(minPackedValue, maxPackedValue);
                 // compute range relation for BKD traversal
                 if (comparator.isDisjoint(node)) {


### PR DESCRIPTION
Running against your example core, a bare contains IntRangeQuery drops from 1.6 seconds to 1.1 seconds with this change.  Still not brilliant, but a definite improvement.